### PR TITLE
Add FastAPI JWT example with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-# FastAPI_SimpleTest
-A basic FastAPI project designed for learning and testing core functionalities of FastAPI. It includes simple route management, data validation with Pydantic, and an example REST API endpoint. The project is structured for easy scalability and integration with databases, making it a great starting point for FastAPI development.
+# FastAPI Simple Test
+
+This project is a minimal FastAPI application demonstrating:
+
+- JWT authentication
+- User management with SQLAlchemy
+- Data validation with Pydantic
+- SQLite database
+- Modular architecture (models, routers, services)
+- Automatic OpenAPI documentation
+- Pytest tests
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Application
+
+```bash
+uvicorn app.main:app --reload
+```
+
+The API documentation will be available at `http://localhost:8000/docs`.
+
+## Running Tests
+
+```bash
+pytest
+```
+

--- a/app/core/security.py
+++ b/app/core/security.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+from typing import Optional
+
+from jose import JWTError, jwt
+
+SECRET_KEY = "secret"  # in production use env var
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=15))
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def verify_password(plain_password, hashed_password):
+    return pwd_context.verify(plain_password, hashed_password)
+
+
+def get_password_hash(password):
+    return pwd_context.hash(password)
+

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,13 @@
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base = declarative_base()
+

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+from .routers import auth, items
+from .database import Base, engine
+
+app = FastAPI()
+
+
+@app.on_event("startup")
+def on_startup():
+    Base.metadata.create_all(bind=engine)
+
+app.include_router(auth.router)
+app.include_router(items.router)
+

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,0 +1,2 @@
+from .user import User
+

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,0 +1,10 @@
+from sqlalchemy import Column, Integer, String
+from ..database import Base
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    username = Column(String, unique=True, index=True)
+    hashed_password = Column(String)
+

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,4 @@
+from . import auth, items
+
+__all__ = ["auth", "items"]
+

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.orm import Session
+
+from .. import schemas
+from ..services import auth_service
+from ..core import security
+
+router = APIRouter(prefix="", tags=["auth"])
+
+
+@router.post("/register", response_model=schemas.UserRead)
+def register(user: schemas.UserCreate, db: Session = Depends(auth_service.get_db)):
+    db_user = auth_service.get_user(db, user.username)
+    if db_user:
+        raise HTTPException(status_code=400, detail="Username already registered")
+    user = auth_service.create_user(db, user)
+    return user
+
+
+@router.post("/token", response_model=schemas.Token)
+def login(form_data: OAuth2PasswordRequestForm = Depends(), db: Session = Depends(auth_service.get_db)):
+    user = auth_service.authenticate_user(db, form_data.username, form_data.password)
+    if not user:
+        raise HTTPException(status_code=400, detail="Incorrect username or password")
+    access_token_expires = timedelta(minutes=security.ACCESS_TOKEN_EXPIRE_MINUTES)
+    access_token = security.create_access_token(
+        data={"sub": user.username}, expires_delta=access_token_expires
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
+

--- a/app/routers/items.py
+++ b/app/routers/items.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+
+from ..services import auth_service
+from ..schemas import UserRead
+
+router = APIRouter(prefix="/items", tags=["items"])
+
+
+@router.get("/me", response_model=UserRead)
+async def read_users_me(current_user=Depends(auth_service.get_current_user)):
+    return current_user
+

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,0 +1,2 @@
+from .user import UserCreate, UserRead, Token
+

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,0 +1,18 @@
+from pydantic import BaseModel
+
+class UserBase(BaseModel):
+    username: str
+
+class UserCreate(UserBase):
+    password: str
+
+class UserRead(UserBase):
+    id: int
+
+    class Config:
+        orm_mode = True
+
+class Token(BaseModel):
+    access_token: str
+    token_type: str
+

--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,0 +1,16 @@
+from .auth_service import (
+    get_db,
+    get_user,
+    create_user,
+    authenticate_user,
+    get_current_user,
+)
+
+__all__ = [
+    "get_db",
+    "get_user",
+    "create_user",
+    "authenticate_user",
+    "get_current_user",
+]
+

--- a/app/services/auth_service.py
+++ b/app/services/auth_service.py
@@ -1,0 +1,60 @@
+from sqlalchemy.orm import Session
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import JWTError
+
+from .. import models, schemas
+from ..database import SessionLocal
+from ..core import security
+
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="token")
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def get_user(db: Session, username: str):
+    return db.query(models.User).filter(models.User.username == username).first()
+
+
+def create_user(db: Session, user: schemas.UserCreate):
+    hashed_password = security.get_password_hash(user.password)
+    db_user = models.User(username=user.username, hashed_password=hashed_password)
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+def authenticate_user(db: Session, username: str, password: str):
+    user = get_user(db, username)
+    if not user:
+        return False
+    if not security.verify_password(password, user.hashed_password):
+        return False
+    return user
+
+
+async def get_current_user(token: str = Depends(oauth2_scheme), db: Session = Depends(get_db)):
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+    try:
+        payload = security.jwt.decode(token, security.SECRET_KEY, algorithms=[security.ALGORITHM])
+        username: str = payload.get("sub")
+        if username is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+    user = get_user(db, username)
+    if user is None:
+        raise credentials_exception
+    return user
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+uvicorn
+SQLAlchemy
+pydantic
+passlib[bcrypt]
+python-jose
+pytest
+

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,35 @@
+import os
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.database import Base, engine, SessionLocal
+
+client = TestClient(app)
+
+
+def setup_module(module):
+    # ensure fresh db
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+    Base.metadata.create_all(bind=engine)
+
+
+def test_register_and_login():
+    response = client.post("/register", json={"username": "alice", "password": "secret"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "alice"
+    assert "id" in data
+
+    # login
+    response = client.post("/token", data={"username": "alice", "password": "secret"})
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    assert token
+
+    # access protected route
+    response = client.get("/items/me", headers={"Authorization": f"Bearer {token}"})
+    assert response.status_code == 200
+    data = response.json()
+    assert data["username"] == "alice"


### PR DESCRIPTION
## Summary
- implement FastAPI app using SQLite and JWT authentication
- add routers, services, and models
- provide pytest suite
- document setup in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d99afdd6c83309ffb3b6055153732