### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Test database
+test.db
+
+# Pytest cache
+.pytest_cache/
+
+# Coverage reports
+htmlcov/
+.coverage
+coverage.xml
+
+# Virtual environments
+venv/
+.env/
+.venv/
+
+# Distribution / packaging
+*.egg-info/
+
+# Editors
+.vscode/
+.idea/
+
+# MacOS
+.DS_Store


### PR DESCRIPTION
## Summary
- keep repository clean by ignoring common artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d9c883950833080585fc1fa7a7cfb