### PR TITLE
Add httpx dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pydantic
 passlib[bcrypt]
 python-jose
 pytest
-
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: cannot connect to pypi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d9c86d4f88330876719ab6793d208