### PR TITLE
Fix unused import in auth tests

### DIFF
--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from app.main import app
-from app.database import Base, engine, SessionLocal
+from app.database import Base, engine
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- clean up imports in `tests/test_auth.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_684d9c868ac88330893286969865b06d