### PR TITLE
Add root route to main app

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -13,3 +13,8 @@ def on_startup():
 app.include_router(auth.router)
 app.include_router(items.router)
 
+
+@app.get("/")
+async def read_root():
+    return {"message": "Hello World"}
+


### PR DESCRIPTION
## Summary
- add a GET `/` endpoint to return a welcome message

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_684d9c8480008330b03758994cfb7d42