### PR TITLE
Improve docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,54 @@
-# FastAPI Simple Test
+# Cyberpunk Task Board
 
-This project is a minimal **FastAPI** API accompanied by a **Flask** front-end. The API demonstrates:
+This repository contains a small **FastAPI** backend with a **Flask** front‑end.
+The front‑end uses TailwindCSS and JavaScript to present a cyberpunk styled
+interface that interacts with the API via HTTP calls.
 
-- JWT authentication
-- User management with SQLAlchemy
-- Data validation with Pydantic
-- SQLite database
-- Modular architecture (models, routers, services)
-- Automatic OpenAPI documentation
-- Pytest tests
+## Features
 
-The Flask application renders HTML templates (using Jinja2, TailwindCSS and JavaScript) that consume the FastAPI service via HTTP calls.
+- JWT authentication and user registration.
+- SQLite database managed by SQLAlchemy.
+- Modular architecture with routers and services.
+- Flask blueprint for the front‑end.
+- Pytest test suite covering the API and the Flask routes.
 
 ## Installation
 
-```bash
-pip install -r requirements.txt
-```
+1. Create a virtual environment and install the dependencies:
 
-## Running the Application
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. (Optional) set the environment variable `FASTAPI_URL` for the Flask app. It
+   defaults to `http://localhost:8000`.
+
+## Running the applications
+
+Start the FastAPI server:
 
 ```bash
 uvicorn app.main:app --reload
 ```
 
-### Running the Flask Front-end
-
-Set the environment variable `FASTAPI_URL` to the URL where the FastAPI app is running (default `http://localhost:8000`). Then start the Flask development server:
+In a separate terminal run the Flask front‑end:
 
 ```bash
 python -m frontend.app
 ```
 
-Open `http://localhost:5000` in your browser to see the cyberpunk task board.
+Open `http://localhost:5000` to see the task board. The API documentation is
+available at `http://localhost:8000/docs`.
 
-The API documentation will be available at `http://localhost:8000/docs`.
+## Running the tests
 
-## Running Tests
+The project includes unit and integration tests for both the API and the front
+end. Execute them with:
 
 ```bash
-pytest
+pytest --cov
 ```
+
+A coverage report will be produced in the terminal. Aim for a coverage above
+90 %.
 

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -11,16 +11,22 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 @router.get("/", response_model=list[schemas.TaskRead])
 def list_tasks(db: Session = Depends(auth_service.get_db)):
+    """Return all tasks."""
+
     return task_service.get_tasks(db)
 
 
 @router.post("/", response_model=schemas.TaskRead)
 def create_task(task: schemas.TaskCreate, db: Session = Depends(auth_service.get_db)):
+    """Create a new task and return it."""
+
     return task_service.create_task(db, task)
 
 
 @router.delete("/{task_id}", status_code=204)
 def delete_task(task_id: int, db: Session = Depends(auth_service.get_db)):
+    """Remove a task from the database."""
+
     task = task_service.delete_task(db, task_id)
     if not task:
         raise HTTPException(status_code=404, detail="Task not found")

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -6,10 +6,14 @@ from .. import models, schemas
 
 
 def get_tasks(db: Session):
+    """Return all tasks stored in the database."""
+
     return db.query(models.Task).all()
 
 
 def create_task(db: Session, task: schemas.TaskCreate):
+    """Persist a new task and return it."""
+
     db_task = models.Task(title=task.title, description=task.description)
     db.add(db_task)
     db.commit()
@@ -18,6 +22,8 @@ def create_task(db: Session, task: schemas.TaskCreate):
 
 
 def delete_task(db: Session, task_id: int):
+    """Delete a task by id returning the removed object if found."""
+
     task = db.query(models.Task).get(task_id)
     if task:
         db.delete(task)

--- a/frontend/__init__.py
+++ b/frontend/__init__.py
@@ -1,7 +1,11 @@
+"""Application factory for the Flask front-end."""
+
 from flask import Flask
 
 
-def create_app():
+def create_app() -> Flask:
+    """Create and configure the Flask application instance."""
+
     app = Flask(__name__)
 
     from .routes.main import bp as main_bp

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,3 +1,5 @@
+"""Entry point for running the Flask development server."""
+
 from . import create_app
 
 app = create_app()

--- a/frontend/routes/main.py
+++ b/frontend/routes/main.py
@@ -1,3 +1,5 @@
+"""Blueprint containing the main page route."""
+
 from flask import Blueprint, render_template
 import os
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,0 +1,15 @@
+"""Tests for the Flask front-end routes."""
+
+import os
+from frontend import create_app
+
+
+def test_index_route():
+    """Index should render with the API URL injected."""
+    os.environ['FASTAPI_URL'] = 'http://api'
+    app = create_app()
+    client = app.test_client()
+
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'Cyberpunk Task Board' in response.data

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,0 +1,41 @@
+"""Integration tests for task CRUD endpoints."""
+
+import os
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.database import Base, engine
+
+client = TestClient(app)
+
+
+def setup_module(module):
+    """Ensure a clean database for task tests."""
+    if os.path.exists("test.db"):
+        os.remove("test.db")
+    Base.metadata.create_all(bind=engine)
+
+
+def test_task_crud_flow():
+    """Create, list and delete tasks through the API."""
+
+    # Create a new task
+    response = client.post("/tasks/", json={"title": "Test", "description": "demo"})
+    assert response.status_code == 200
+    task = response.json()
+    assert task["title"] == "Test"
+
+    # List tasks should contain the created one
+    response = client.get("/tasks/")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+
+    # Delete the task
+    response = client.delete(f"/tasks/{task['id']}")
+    assert response.status_code == 204
+
+    # Ensure list is empty again
+    response = client.get("/tasks/")
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- document flask entry points
- document task router and services
- add integration tests and flask tests
- rewrite README with clearer instructions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68512ee16e5083308d7208a4bf39b661